### PR TITLE
Refactor column type guessing

### DIFF
--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -335,7 +335,7 @@ class Dataset:
             "period": other_cols,
             "mixed": mixed_type_cols,
             "interval": numerical_cols,
-            "category": categorical_cols,  # TODO: handle already categorical
+            "category": categorical_cols,
             "categorical": categorical_cols,
         }
 
@@ -348,6 +348,14 @@ class Dataset:
         med_exam_col_list = (
             numerical_cols | bool_cols - constant_cols - self.metadata_cols
         )
+
+        for categorical_col in categorical_cols:
+            if categorical_col.dtype.categories.inferred_type == "integer":
+                num_categorical_cols.add(categorical_col)
+            elif categorical_col.dtype.categories.inferred_type == "string":
+                str_categorical_cols.add(categorical_col)
+            else:
+                raise RuntimeError("there is something wrong with the type guessing...")
 
         return _ColumnListByType(
             mixed_type_cols=mixed_type_cols,

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -4,7 +4,7 @@ import dbm
 import logging
 import os
 import shelve
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import DefaultDict, Dict, List, Set, Tuple, Union
 
@@ -185,15 +185,15 @@ class _ColumnListByType:
     The columns are split according to the type of their values.
     """
 
-    constant_cols: Set
-    mixed_type_cols: Set
-    numerical_cols: Set
-    med_exam_col_list: Set
-    str_cols: Set
-    str_categorical_cols: Set
-    num_categorical_cols: Set
-    other_cols: Set
-    bool_cols: Set
+    constant_cols: Set = field(default_factory=set)
+    mixed_type_cols: Set = field(default_factory=set)
+    numerical_cols: Set = field(default_factory=set)
+    med_exam_col_list: Set = field(default_factory=set)
+    str_cols: Set = field(default_factory=set)
+    str_categorical_cols: Set = field(default_factory=set)
+    num_categorical_cols: Set = field(default_factory=set)
+    other_cols: Set = field(default_factory=set)
+    bool_cols: Set = field(default_factory=set)
 
     def __str__(self):
         return (

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -384,16 +384,6 @@ class Dataset:
         #  not be included in num_categorical_cols just for one not-Nan value)
 
         col_list = self.feature_cols - constant_cols
-        """
-        (
-            mixed_type_cols,
-            numerical_cols,
-            str_cols,
-            bool_cols,
-            other_cols,
-        ) = _split_columns_by_type_parallel(self.df, col_list)
-        """
-        cols_type = []
 
         mixed_type_cols = set()
         numerical_cols = set()

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -363,10 +363,24 @@ class Dataset:
 
     @property
     def mixed_type_columns(self) -> Set[str]:
+        """Return the name of the columns with mixed type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with mixed type
+        """
         return self._columns_type.mixed_type_cols
 
     @property
     def numerical_columns(self) -> Set[str]:
+        """Return the name of the columns with numerical type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with numerical type
+        """
         return self._columns_type.numerical_cols
 
     @property
@@ -388,22 +402,60 @@ class Dataset:
 
     @property
     def str_columns(self) -> Set[str]:
+        """Return the name of the columns with string type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with string type
+        """
         return self._columns_type.str_cols
 
     @property
     def str_categorical_columns(self) -> Set[str]:
+        """Return the name of the columns with string categorical type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with string categorical type
+        """
         return self._columns_type.str_categorical_cols
 
     @property
     def num_categorical_columns(self) -> Set[str]:
+        """Return the name of the columns with numerical categorical type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with numerical categorical type
+        """
         return self._columns_type.num_categorical_cols
 
     @property
     def bool_columns(self) -> Set[str]:
+        """Return the name of the columns with boolean type.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with boolean type
+        """
         return self._columns_type.bool_cols
 
     @property
     def other_type_columns(self) -> Set[str]:
+        """Return the name of the columns with non-conventional type.
+
+        Types that are included in this category are: bytes, datetime64, datetime, date,
+        timedelta64, timedelta, time, period.
+
+        Returns
+        -------
+        Set[str]
+            The names of the columns with non-conventional type
+        """
         return self._columns_type.other_cols
 
     def _get_categorical_cols(self, col_list: Tuple[str]) -> Set[str]:

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -384,7 +384,7 @@ class Dataset:
         #  not be included in num_categorical_cols just for one not-Nan value)
 
         col_list = self.feature_cols - constant_cols
-
+        """
         (
             mixed_type_cols,
             numerical_cols,
@@ -392,6 +392,39 @@ class Dataset:
             bool_cols,
             other_cols,
         ) = _split_columns_by_type_parallel(self.df, col_list)
+        """
+        cols_type = []
+
+        mixed_type_cols = set()
+        numerical_cols = set()
+        str_cols = set()
+        bool_cols = set()
+        other_cols = set()
+
+        PD_INFER_TYPE_MAP = {
+            "string": str_cols,
+            "bytes": other_cols,
+            "floating": numerical_cols,
+            "integer": numerical_cols,
+            "mixed-integer": mixed_type_cols,
+            "mixed-integer-float": numerical_cols,
+            "decimal": numerical_cols,
+            "complex": numerical_cols,
+            "boolean": bool_cols,
+            "datetime64": other_cols,
+            "datetime": other_cols,
+            "date": other_cols,
+            "timedelta64": other_cols,
+            "timedelta": other_cols,
+            "time": other_cols,
+            "period": other_cols,
+            "mixed": mixed_type_cols,
+            "interval": numerical_cols,
+        }
+
+        for col in col_list:
+            col_type = pd.api.types.infer_dtype(self.df[col], skipna=True)
+            PD_INFER_TYPE_MAP[col_type].add(col)
 
         str_categorical_cols = self._get_categorical_cols(str_cols)
         num_categorical_cols = self._get_categorical_cols(numerical_cols)

--- a/src/trousse/util.py
+++ b/src/trousse/util.py
@@ -1,0 +1,6 @@
+import functools
+from typing import Any, Callable
+
+
+def lazy_property(f: Callable[..., Any]):
+    return property(functools.lru_cache()(f))

--- a/tests/dataset_util.py
+++ b/tests/dataset_util.py
@@ -211,11 +211,9 @@ class DataFrameMock:
             "str_categorical_col": pd.Series(
                 ["category_0", "category_1", "category_2", "category_3", "category_4"]
                 * (sample_size // 5),
-                dtype="category",
             ),
             "num_categorical_col": pd.Series(
                 [0, 1, 2, 3, 4] * (sample_size // 5),
-                dtype="category",
             ),
             "numerical_col": [0.05 * i for i in range(sample_size)],
             "datetime_col": [date(2000 + i, 8, 1) for i in range(sample_size)],

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -7,9 +7,9 @@ import pandas as pd
 import pytest
 
 from trousse.dataset import (
-    ColumnListByType,
     Dataset,
     FeatureOperation,
+    _ColumnListByType,
     _find_samples_by_type,
     _find_single_column_type,
     _split_columns_by_type_parallel,
@@ -164,7 +164,7 @@ class Describe_Dataset:
         [
             (
                 {"metadata_num_col"},
-                ColumnListByType(
+                _ColumnListByType(
                     mixed_type_cols=set(),
                     constant_cols=set(),
                     numerical_cols={
@@ -193,7 +193,7 @@ class Describe_Dataset:
                     "str_categorical_col",
                     "datetime_col",
                 },
-                ColumnListByType(
+                _ColumnListByType(
                     mixed_type_cols={"mixed_type_col"},
                     constant_cols={"same_col"},
                     numerical_cols={
@@ -219,7 +219,7 @@ class Describe_Dataset:
             ),
             (
                 None,
-                ColumnListByType(
+                _ColumnListByType(
                     mixed_type_cols={"mixed_type_col"},
                     constant_cols={"same_col"},
                     numerical_cols={
@@ -253,9 +253,9 @@ class Describe_Dataset:
             feature_cols=feature_cols,
         )
 
-        col_list_by_type = dataset.column_list_by_type
+        col_list_by_type = dataset._columns_type
 
-        assert isinstance(col_list_by_type, ColumnListByType)
+        assert isinstance(col_list_by_type, _ColumnListByType)
         assert col_list_by_type == expected_column_list_type
 
     @pytest.mark.parametrize(

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -10,9 +10,7 @@ from trousse.dataset import (
     Dataset,
     FeatureOperation,
     _ColumnListByType,
-    _find_samples_by_type,
     _find_single_column_type,
-    _split_columns_by_type_parallel,
     copy_dataset_with_new_df,
     get_df_from_csv,
     read_file,
@@ -846,54 +844,6 @@ def test_find_single_column_type(request, series_type, expected_col_type_dict):
     col_type_dict = _find_single_column_type(serie)
 
     assert col_type_dict == expected_col_type_dict
-
-
-@pytest.mark.parametrize(
-    "col_type, expected_column_single_type_set",
-    [
-        ("bool_col", {"bool_col_0", "bool_col_1"}),
-        ("string_col", {"string_col_0", "string_col_1", "string_col_2"}),
-        ("numerical_col", {"numerical_col_0"}),
-        ("other_col", {"other_col_0"}),
-        (
-            "mixed_type_col",
-            {
-                "mixed_type_col_0",
-                "mixed_type_col_1",
-                "mixed_type_col_2",
-                "mixed_type_col_3",
-            },
-        ),
-    ],
-)
-def test_find_columns_by_type(request, col_type, expected_column_single_type_set):
-    df_col_names_by_type = DataFrameMock.df_column_names_by_type()
-
-    column_single_type_set = _find_samples_by_type(df_col_names_by_type, col_type)
-
-    assert column_single_type_set == expected_column_single_type_set
-
-
-def test_split_columns_by_type_parallel(request):
-    df_by_type = DataFrameMock.df_multi_type(sample_size=10)
-    col_list = df_by_type.columns
-
-    cols_by_type_tuple = _split_columns_by_type_parallel(df_by_type, col_list)
-
-    assert cols_by_type_tuple == (
-        {"mixed_type_col"},
-        {
-            "numerical_col",
-            "interval_col",
-            "num_categorical_col",
-            "nan_col",
-            "metadata_num_col",
-            "same_col",
-        },
-        {"string_col", "str_categorical_col"},
-        {"bool_col"},
-        {"datetime_col"},
-    )
 
 
 def test_copy_dataset_with_new_df(dataset_with_operations):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,8 +1,9 @@
 import pytest
 
-from trousse.dataset import Dataset
+from trousse.dataset import Dataset, _ColumnListByType
 
 from ..dataset_util import DataFrameMock
+from ..unitutil import initializer_mock, instance_mock, property_mock
 
 
 class DescribeDataset:
@@ -15,7 +16,6 @@ class DescribeDataset:
         ],
     )
     def it_knows_its_metadata_cols(self, metadata_cols):
-
         df = DataFrameMock.df_multi_type(10)
         dataset = Dataset(df_object=df, metadata_cols=metadata_cols)
 
@@ -67,3 +67,105 @@ class DescribeDataset:
 
         assert type(feature_cols_) == set
         assert feature_cols_ == expected_feature_cols
+
+    def it_knows_its_mixed_type_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(mixed_type_cols={"mixed0", "mixed1"})
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        mixed_type_columns_ = dataset.mixed_type_columns
+
+        assert type(mixed_type_columns_) == set
+        assert mixed_type_columns_ == {"mixed0", "mixed1"}
+
+    def it_knows_its_numerical_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(
+            numerical_cols={"numerical0", "numerical1"}
+        )
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        numerical_columns_ = dataset.numerical_columns
+
+        assert type(numerical_columns_) == set
+        assert numerical_columns_ == {"numerical0", "numerical1"}
+
+    def it_knows_its_med_exam_col_list(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(med_exam_col_list={"med0", "med1"})
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        med_exam_col_list_ = dataset.med_exam_col_list
+
+        assert type(med_exam_col_list_) == set
+        assert med_exam_col_list_ == {"med0", "med1"}
+
+    def it_knows_its_str_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(str_cols={"str0", "str1"})
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        str_columns_ = dataset.str_columns
+
+        assert type(str_columns_) == set
+        assert str_columns_ == {"str0", "str1"}
+
+    def it_knows_its_str_categorical_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(
+            str_categorical_cols={"strcat0", "strcat1"}
+        )
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        str_categorical_columns_ = dataset.str_categorical_columns
+
+        assert type(str_categorical_columns_) == set
+        assert str_categorical_columns_ == {"strcat0", "strcat1"}
+
+    def it_knows_its_num_categorical_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(
+            num_categorical_cols={"numcat0", "numcat1"}
+        )
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        num_categorical_columns_ = dataset.num_categorical_columns
+
+        assert type(num_categorical_columns_) == set
+        assert num_categorical_columns_ == {"numcat0", "numcat1"}
+
+    def it_knows_its_bool_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(bool_cols={"bool0", "bool1"})
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        bool_columns_ = dataset.bool_columns
+
+        assert type(bool_columns_) == set
+        assert bool_columns_ == {"bool0", "bool1"}
+
+    def it_knows_its_other_type_columns(self, request):
+        _columns_type = property_mock(request, Dataset, "_columns_type")
+        column_list_by_type = _ColumnListByType(other_cols={"other0", "other1"})
+        _columns_type.return_value = column_list_by_type
+        _init = initializer_mock(request, Dataset)
+        dataset = Dataset(data_file="fake/path")
+
+        other_type_columns_ = dataset.other_type_columns
+
+        assert type(other_type_columns_) == set
+        assert other_type_columns_ == {"other0", "other1"}

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -3,7 +3,7 @@ import pytest
 from trousse.dataset import Dataset, _ColumnListByType
 
 from ..dataset_util import DataFrameMock
-from ..unitutil import initializer_mock, instance_mock, property_mock
+from ..unitutil import initializer_mock, property_mock
 
 
 class DescribeDataset:
@@ -72,7 +72,7 @@ class DescribeDataset:
         _columns_type = property_mock(request, Dataset, "_columns_type")
         column_list_by_type = _ColumnListByType(mixed_type_cols={"mixed0", "mixed1"})
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         mixed_type_columns_ = dataset.mixed_type_columns
@@ -86,7 +86,7 @@ class DescribeDataset:
             numerical_cols={"numerical0", "numerical1"}
         )
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         numerical_columns_ = dataset.numerical_columns
@@ -98,7 +98,7 @@ class DescribeDataset:
         _columns_type = property_mock(request, Dataset, "_columns_type")
         column_list_by_type = _ColumnListByType(med_exam_col_list={"med0", "med1"})
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         med_exam_col_list_ = dataset.med_exam_col_list
@@ -110,7 +110,7 @@ class DescribeDataset:
         _columns_type = property_mock(request, Dataset, "_columns_type")
         column_list_by_type = _ColumnListByType(str_cols={"str0", "str1"})
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         str_columns_ = dataset.str_columns
@@ -124,7 +124,7 @@ class DescribeDataset:
             str_categorical_cols={"strcat0", "strcat1"}
         )
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         str_categorical_columns_ = dataset.str_categorical_columns
@@ -138,7 +138,7 @@ class DescribeDataset:
             num_categorical_cols={"numcat0", "numcat1"}
         )
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         num_categorical_columns_ = dataset.num_categorical_columns
@@ -150,7 +150,7 @@ class DescribeDataset:
         _columns_type = property_mock(request, Dataset, "_columns_type")
         column_list_by_type = _ColumnListByType(bool_cols={"bool0", "bool1"})
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         bool_columns_ = dataset.bool_columns
@@ -162,7 +162,7 @@ class DescribeDataset:
         _columns_type = property_mock(request, Dataset, "_columns_type")
         column_list_by_type = _ColumnListByType(other_cols={"other0", "other1"})
         _columns_type.return_value = column_list_by_type
-        _init = initializer_mock(request, Dataset)
+        initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
         other_type_columns_ = dataset.other_type_columns

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -79,6 +79,7 @@ class DescribeDataset:
 
         assert type(mixed_type_columns_) == set
         assert mixed_type_columns_ == {"mixed0", "mixed1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_numerical_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -93,6 +94,7 @@ class DescribeDataset:
 
         assert type(numerical_columns_) == set
         assert numerical_columns_ == {"numerical0", "numerical1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_med_exam_col_list(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -105,6 +107,7 @@ class DescribeDataset:
 
         assert type(med_exam_col_list_) == set
         assert med_exam_col_list_ == {"med0", "med1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_str_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -117,6 +120,7 @@ class DescribeDataset:
 
         assert type(str_columns_) == set
         assert str_columns_ == {"str0", "str1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_str_categorical_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -131,6 +135,7 @@ class DescribeDataset:
 
         assert type(str_categorical_columns_) == set
         assert str_categorical_columns_ == {"strcat0", "strcat1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_num_categorical_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -145,6 +150,7 @@ class DescribeDataset:
 
         assert type(num_categorical_columns_) == set
         assert num_categorical_columns_ == {"numcat0", "numcat1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_bool_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -157,6 +163,7 @@ class DescribeDataset:
 
         assert type(bool_columns_) == set
         assert bool_columns_ == {"bool0", "bool1"}
+        _columns_type.assert_called_once()
 
     def it_knows_its_other_type_columns(self, request):
         _columns_type = property_mock(request, Dataset, "_columns_type")
@@ -169,3 +176,4 @@ class DescribeDataset:
 
         assert type(other_type_columns_) == set
         assert other_type_columns_ == {"other0", "other1"}
+        _columns_type.assert_called_once()


### PR DESCRIPTION
- Use pandas utils to guess the column type
- Each set of column names divided by type is now stored in a property

fixes #45