### PR TITLE
Revert "FillNA can only work on single column"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Along with the common preprocessing utilities (for encoding, binning, scaling, e
 >>> fillna_replacestrings = Compose(
     [
         FillNA(
-            column="column_with_nan",
-            derived_column="column_filled",
+            columns=["column_with_nan"],
+            derived_columns=["column_filled"],
             value=0,
         ),
         ReplaceSubstrings(
-            column="column_invalid_values",
-            derived_column="column_valid_values",
+            columns=["column_invalid_values"],
+            derived_columns=["column_valid_values"],
             replacement_map={",": ".", "°": ""},
         ),
     ]
@@ -93,13 +93,13 @@ PyTrousse automagically tracks every dataset transformation which can be inspect
 ```bash
 [
     FillNA(
-        column="column_with_nan",
-        derived_column="column_filled",
+        columns=["column_with_nan"],
+        derived_columns=["column_filled"],
         value=0,
     ),
     ReplaceSubstrings(
-        column="column_invalid_values",
-        derived_column="column_valid_values",
+        columns=["column_invalid_values"],
+        derived_columns=["column_valid_values"],
         replacement_map={",": ".", "°": ""},
     ),
 ]

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -914,26 +914,26 @@ class Dataset:
 
     def fillna(
         self,
-        column: str,
+        columns: Union[List[str], str],
         value: Any,
-        derived_column: str = None,
+        derived_columns: Union[List[str], str] = None,
         inplace: bool = False,
     ) -> Optional["Dataset"]:
-        """Fill NaN values in ``column`` column with value ``value``.
+        """Fill NaN values in ``columns`` columns with value ``value``.
 
-        By default NaNs are filled in the original column. To store the result of filling
-        in other column, ``derived_column`` parameter has to be set with the name of
-        the corresponding column name.
+        By default NaNs are filled in the original columns. To store the result of filling
+        in other columns, ``derived_columns`` parameter has to be set with the name of
+        the corresponding column names.
 
         Parameters
         ----------
-        column : str
-            Name of the column with NaNs to be filled
+        columns : Union[List[str], str]
+            Names of the columns with NaNs to be filled
         value : Any
             Value used to fill the NaNs
-        derived_column : str, optional
-            Name of the column where to store the filling result. Default is None,
-            meaning that NaNs are filled in the original column.
+        derived_columns : Union[List[str], str], optional
+            Names of the columns where to store the filling result. Default is None,
+            meaning that NaNs are filled in the original columns.
         inplace : bool, optional
             Whether to modify the current Dataset or return a new instance. Default False,
             meanining that a new instance of Dataset will be returned.
@@ -945,27 +945,35 @@ class Dataset:
 
         Raises
         ------
-        TypeError
-            If ``column`` or ``derived_column`` are not strings
+        ValueError
+            If the number of columns to be filled is different from the number of the
+            columns where to store the result (if ``derived_columns`` is not None)
         """
-        if not isinstance(column, str):
-            raise TypeError(
-                f"column parameter must be a string, found {type(column).__name__}"
-            )
         if not inplace:
             dataset = self._dataset_copy
         else:
             dataset = self
 
-        if derived_column:
-            if not isinstance(derived_column, str):
-                raise TypeError(
-                    f"derived_column parameter must be a string, found {type(derived_column).__name__}"
+        if not isinstance(columns, list):
+            columns = [columns]
+
+        if derived_columns:
+            if not isinstance(derived_columns, list):
+                derived_columns = [derived_columns]
+
+            if len(columns) != len(derived_columns):
+                raise ValueError(
+                    f"The number of derived_columns ({len(derived_columns)}) "
+                    f"must be equal to the number of columns ({len(columns)})"
                 )
-            filled_col = dataset.df[column].fillna(value, inplace=False)
-            dataset._df[derived_column] = filled_col
+
+            for column, derived_column in zip(columns, derived_columns):
+                filled_col = dataset.df[column].fillna(value, inplace=False)
+                dataset._df[derived_column] = filled_col
+
         else:
-            dataset.df[column].fillna(value, inplace=True)
+            for column in columns:
+                dataset.df[column].fillna(value, inplace=True)
 
         if not inplace:
             return dataset

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -914,12 +914,12 @@ class Dataset:
 
     def fillna(
         self,
-        columns: Union[List[str], str],
+        columns: List[str],
         value: Any,
-        derived_columns: Union[List[str], str] = None,
+        derived_columns: List[str] = None,
         inplace: bool = False,
     ) -> Optional["Dataset"]:
-        """Fill NaN values in ``columns`` columns with value ``value``.
+        """Fill NaN values ``columns`` (single-element list) column with value ``value``.
 
         By default NaNs are filled in the original columns. To store the result of filling
         in other columns, ``derived_columns`` parameter has to be set with the name of
@@ -927,13 +927,14 @@ class Dataset:
 
         Parameters
         ----------
-        columns : Union[List[str], str]
-            Names of the columns with NaNs to be filled
+        columns : List[str]
+            Name of the column with NaNs to be filled. It must be a single-element list.
         value : Any
             Value used to fill the NaNs
-        derived_columns : Union[List[str], str], optional
-            Names of the columns where to store the filling result. Default is None,
-            meaning that NaNs are filled in the original columns.
+        derived_columns : List[str], optional
+            Name of the column where to store the filling result. Default is None,
+            meaning that NaNs are filled in the original column. If not None, it must be
+            a single-element list.
         inplace : bool, optional
             Whether to modify the current Dataset or return a new instance. Default False,
             meanining that a new instance of Dataset will be returned.
@@ -946,34 +947,27 @@ class Dataset:
         Raises
         ------
         ValueError
-            If the number of columns to be filled is different from the number of the
-            columns where to store the result (if ``derived_columns`` is not None)
+            If ``columns`` or ``derived_columns`` are not a single-element list.
         """
+        if len(columns) != 1:
+            raise ValueError(f"Length of columns must be 1, found {len(columns)}")
+
         if not inplace:
             dataset = self._dataset_copy
         else:
             dataset = self
 
-        if not isinstance(columns, list):
-            columns = [columns]
-
         if derived_columns:
-            if not isinstance(derived_columns, list):
-                derived_columns = [derived_columns]
-
-            if len(columns) != len(derived_columns):
+            if len(derived_columns) != 1:
                 raise ValueError(
-                    f"The number of derived_columns ({len(derived_columns)}) "
-                    f"must be equal to the number of columns ({len(columns)})"
+                    f"Length of derived_columns must be 1, found {len(derived_columns)}"
                 )
 
-            for column, derived_column in zip(columns, derived_columns):
-                filled_col = dataset.df[column].fillna(value, inplace=False)
-                dataset._df[derived_column] = filled_col
+            filled_col = dataset.df[columns[0]].fillna(value, inplace=False)
+            dataset._df[derived_columns[0]] = filled_col
 
         else:
-            for column in columns:
-                dataset.df[column].fillna(value, inplace=True)
+            dataset.df[columns[0]].fillna(value, inplace=True)
 
         if not inplace:
             return dataset

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -4,7 +4,7 @@ except ImportError:
     from typing_extensions import Protocol, runtime_checkable
 
 from abc import abstractmethod
-from typing import Any, List, Union
+from typing import Any, List
 
 from .dataset import Dataset
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -13,6 +13,9 @@ from .dataset import Dataset
 class FeatureOperation(Protocol):
     """Protocol definining how Operations should be applied on a Dataset."""
 
+    columns: Union[List[str], str]
+    derived_columns: Union[List[str], str] = None
+
     @abstractmethod
     def __call__(self, dataset: Dataset) -> Dataset:
         raise NotImplementedError
@@ -23,21 +26,21 @@ class FeatureOperation(Protocol):
 
 
 class FillNA(FeatureOperation):
-    """Fill NaN values in ``column`` column with value ``value``.
+    """Fill NaN values in ``columns`` columns with value ``value``.
 
-    By default NaNs are filled in the original column. To store the result of filling
-    in other column, ``derived_column`` parameter has to be set with the name of
-    the corresponding column name.
+    By default NaNs are filled in the original columns. To store the result of filling
+    in other columns, ``derived_columns`` parameter has to be set with the name of
+    the corresponding column names.
 
     Parameters
     ----------
-    column : str
-        Name of the column with NaNs to be filled
+    columns : Union[List[str], str]
+        Names of the columns with NaNs to be filled
     value : Any
         Value used to fill the NaNs
-    derived_column : str, optional
-        Names of the column where to store the filling result. Default is None,
-        meaning that NaNs are filled in the original column.
+    derived_columns : Union[List[str], str], optional
+        Names of the columns where to store the filling result. Default is None,
+        meaning that NaNs are filled in the original columns.
 
     Returns
     -------
@@ -46,24 +49,25 @@ class FillNA(FeatureOperation):
 
     Raises
     ------
-    TypeError
-        If ``column`` or ``derived_column`` are not strings
+    ValueError
+        If the number of columns to be filled is different from the number of the
+        columns where to store the result (if ``derived_columns`` is not None)
     """
 
     def __init__(
         self,
-        column: str,
+        columns: Union[List[str], str],
         value: Any,
-        derived_column: str = None,
+        derived_columns: Union[List[str], str] = None,
     ):
-        self.column = column
-        self.derived_column = derived_column
+        self.columns = columns
+        self.derived_columns = derived_columns
         self.value = value
 
     def __call__(self, dataset: Dataset) -> Dataset:
         return dataset.fillna(
-            column=self.column,
-            derived_column=self.derived_column,
+            columns=self.columns,
+            derived_columns=self.derived_columns,
             value=self.value,
             inplace=False,
         )

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -4,7 +4,7 @@ except ImportError:
     from typing_extensions import Protocol, runtime_checkable
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, List, Union
 
 from .dataset import Dataset
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -13,8 +13,8 @@ from .dataset import Dataset
 class FeatureOperation(Protocol):
     """Protocol definining how Operations should be applied on a Dataset."""
 
-    columns: Union[List[str], str]
-    derived_columns: Union[List[str], str] = None
+    columns: List[str]
+    derived_columns: List[str] = None
 
     @abstractmethod
     def __call__(self, dataset: Dataset) -> Dataset:
@@ -26,7 +26,7 @@ class FeatureOperation(Protocol):
 
 
 class FillNA(FeatureOperation):
-    """Fill NaN values in ``columns`` columns with value ``value``.
+    """Fill NaN values ``columns`` (single-element list) column with value ``value``.
 
     By default NaNs are filled in the original columns. To store the result of filling
     in other columns, ``derived_columns`` parameter has to be set with the name of
@@ -34,13 +34,14 @@ class FillNA(FeatureOperation):
 
     Parameters
     ----------
-    columns : Union[List[str], str]
-        Names of the columns with NaNs to be filled
+    columns : List[str]
+        Name of the column with NaNs to be filled. It must be a single-element list.
     value : Any
         Value used to fill the NaNs
-    derived_columns : Union[List[str], str], optional
-        Names of the columns where to store the filling result. Default is None,
-        meaning that NaNs are filled in the original columns.
+    derived_columns : List[str], optional
+        Name of the column where to store the filling result. Default is None,
+        meaning that NaNs are filled in the original column. If not None, it must be a
+        single-element list.
 
     Returns
     -------
@@ -50,16 +51,22 @@ class FillNA(FeatureOperation):
     Raises
     ------
     ValueError
-        If the number of columns to be filled is different from the number of the
-        columns where to store the result (if ``derived_columns`` is not None)
+        If ``columns`` or ``derived_columns`` are not a single-element list.
     """
 
     def __init__(
         self,
-        columns: Union[List[str], str],
+        columns: List[str],
         value: Any,
-        derived_columns: Union[List[str], str] = None,
+        derived_columns: List[str] = None,
     ):
+        if len(columns) != 1:
+            raise ValueError(f"Length of columns must be 1, found {len(columns)}")
+        if derived_columns is not None and len(derived_columns) != 1:
+            raise ValueError(
+                f"Length of derived_columns must be 1, found {len(derived_columns)}"
+            )
+
         self.columns = columns
         self.derived_columns = derived_columns
         self.value = value

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1,5 +1,6 @@
 from unittest.mock import call
 
+import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -228,6 +228,51 @@ class DescribeDataset:
         assert id(dataset) != id(dataset_copy)
 
     @pytest.mark.parametrize(
+        "columns, derived_columns, expected_new_columns, expected_inplace",
+        [
+            (
+                ["nan_0", "nan_1"],
+                ["filled_nan_0", "filled_nan_1"],
+                ["filled_nan_0", "filled_nan_1"],
+                False,
+            ),
+            (["nan_0"], ["filled_nan_0"], ["filled_nan_0"], False),
+            (["nan_0", "nan_1"], None, [], True),
+            (["nan_0"], None, [], True),
+        ],
+    )
+    def it_can_fillna_not_inplace_list(
+        self, request, columns, derived_columns, expected_new_columns, expected_inplace
+    ):
+        pd_fillna_ = method_mock(request, pd.Series, "fillna")
+        pd_fillna_.return_value = pd.Series([0] * 100)
+        _dataset_copy_ = property_mock(request, Dataset, "_dataset_copy")
+        df = DataFrameMock.df_many_nans(nan_ratio=0.5, n_columns=3)
+        get_df_from_csv_ = function_mock(request, "trousse.dataset.get_df_from_csv")
+        get_df_from_csv_.return_value = df
+        _dataset_copy_.return_value = Dataset(data_file="fake/path1")
+        dataset = Dataset(data_file="fake/path0")
+
+        filled_dataset = dataset.fillna(
+            columns=columns, derived_columns=derived_columns, value=0, inplace=False
+        )
+
+        assert filled_dataset is not None
+        assert filled_dataset is not dataset
+        assert isinstance(filled_dataset, Dataset)
+        for col in expected_new_columns:
+            assert col in filled_dataset.df.columns
+        _dataset_copy_.assert_called_once()
+        assert get_df_from_csv_.call_args_list == [
+            call("fake/path1"),
+            call("fake/path0"),
+        ]
+        assert len(pd_fillna_.call_args_list) == len(columns)
+        for i, col in enumerate(columns):
+            pd.testing.assert_series_equal(pd_fillna_.call_args_list[i][0][0], df[col])
+            assert pd_fillna_.call_args_list[i][1] == {"inplace": expected_inplace}
+
+    @pytest.mark.parametrize(
         "column, derived_column, expected_new_column, expected_inplace",
         [
             ("nan_0", "filled_nan_0", ["filled_nan_0"], False),
@@ -247,8 +292,8 @@ class DescribeDataset:
         dataset = Dataset(data_file="fake/path0")
 
         filled_dataset = dataset.fillna(
-            column=column,
-            derived_column=derived_column,
+            columns=column,
+            derived_columns=derived_column,
             value=0,
             inplace=False,
         )
@@ -267,25 +312,42 @@ class DescribeDataset:
         pd.testing.assert_series_equal(pd_fillna_.call_args_list[0][0][0], df[column])
         assert pd_fillna_.call_args_list[0][1] == {"inplace": expected_inplace}
 
-    def but_it_raises_typeerror_if_column_is_not_str(self, request):
+    @pytest.mark.parametrize(
+        "columns",
+        [(["nan_0", "nan_1"]), (["nan_0"]), ("nan_0")],
+    )
+    def it_can_fillna_inplace_list(self, request, columns):
+        df = DataFrameMock.df_many_nans(nan_ratio=0.5, n_columns=3)
+        get_df_from_csv_ = function_mock(request, "trousse.dataset.get_df_from_csv")
+        get_df_from_csv_.return_value = df
+        dataset = Dataset(data_file="fake/path0")
+        old_columns = dataset.df.columns.values
+
+        none = dataset.fillna(
+            columns=columns, derived_columns=None, value=0, inplace=True
+        )
+        new_columns = dataset.df.columns.values
+
+        assert none is None
+        np.testing.assert_array_equal(old_columns, new_columns)
+        get_df_from_csv_.assert_called_once_with("fake/path0")
+
+    def but_it_raises_valueerror_if_columns_and_derived_columns_length_doesnt_match(
+        self, request
+    ):
         initializer_mock(request, Dataset)
         dataset = Dataset(data_file="fake/path")
 
-        with pytest.raises(TypeError) as err:
-            dataset.fillna(column=["nan_0", "nan_1"], derived_column="derived", value=0)
+        with pytest.raises(ValueError) as err:
+            dataset.fillna(
+                columns=["nan_0", "nan_1"], derived_columns=["derived"], value=0
+            )
 
-        assert isinstance(err.value, TypeError)
-        assert str(err.value) == "column parameter must be a string, found list"
-
-    def but_it_raises_typeerror_if_derived_column_is_not_str(self, request):
-        initializer_mock(request, Dataset)
-        dataset = Dataset(data_file="fake/path")
-
-        with pytest.raises(TypeError) as err:
-            dataset.fillna(column="nan_0", derived_column=["derived"], value=0)
-
-        assert isinstance(err.value, TypeError)
-        assert str(err.value) == "derived_column parameter must be a string, found list"
+        assert isinstance(err.value, ValueError)
+        assert (
+            str(err.value)
+            == "The number of derived_columns (1) must be equal to the number of columns (2)"
+        )
 
 
 class DescribeColumnListByType:

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -9,17 +9,19 @@ def it_calls_fillna(request):
     fillna_ = method_mock(request, Dataset, "fillna")
     fillna_.return_value = Dataset("fake/path")
     dataset = Dataset("fake/path")
-    column = "nan_0"
-    derived_column = "filled_0"
+    columns = ["nan_0", "nan_1"]
+    derived_columns = ["filled_0", "filled_1"]
     value = 0
-    fillna_fop = fop.FillNA(column=column, derived_column=derived_column, value=value)
+    fillna_fop = fop.FillNA(
+        columns=columns, derived_columns=derived_columns, value=value
+    )
 
     filled_dataset = fillna_fop(dataset)
 
     fillna_.assert_called_once_with(
         dataset,
-        column=column,
-        derived_column=derived_column,
+        columns=columns,
+        derived_columns=derived_columns,
         value=value,
         inplace=False,
     )

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -27,7 +27,7 @@ class DescribeFillNa:
         self, columns, expected_length
     ):
         with pytest.raises(ValueError) as err:
-            fillna = fop.FillNA(columns=columns, value=0)
+            fop.FillNA(columns=columns, value=0)
 
         assert isinstance(err.value, ValueError)
         assert f"Length of columns must be 1, found {expected_length}" == str(err.value)
@@ -43,9 +43,7 @@ class DescribeFillNa:
         self, derived_columns, expected_length
     ):
         with pytest.raises(ValueError) as err:
-            fillna = fop.FillNA(
-                columns=["nan"], derived_columns=derived_columns, value=0
-            )
+            fop.FillNA(columns=["nan"], derived_columns=derived_columns, value=0)
 
         assert isinstance(err.value, ValueError)
         assert f"Length of derived_columns must be 1, found {expected_length}" == str(

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -1,28 +1,76 @@
+import pytest
 from trousse import feature_operations as fop
 from trousse.dataset import Dataset
 
-from ..unitutil import initializer_mock, method_mock
+from ..unitutil import ANY, initializer_mock, method_mock
 
 
-def it_calls_fillna(request):
-    initializer_mock(request, Dataset)
-    fillna_ = method_mock(request, Dataset, "fillna")
-    fillna_.return_value = Dataset("fake/path")
-    dataset = Dataset("fake/path")
-    columns = ["nan_0", "nan_1"]
-    derived_columns = ["filled_0", "filled_1"]
-    value = 0
-    fillna_fop = fop.FillNA(
-        columns=columns, derived_columns=derived_columns, value=value
+class DescribeFillNa:
+    def it_construct_from_args(self, request):
+        _init_ = initializer_mock(request, fop.FillNA)
+
+        fillna = fop.FillNA(columns=["nan"], derived_columns=["filled"], value=0)
+
+        _init_.assert_called_once_with(
+            ANY, columns=["nan"], derived_columns=["filled"], value=0
+        )
+        assert isinstance(fillna, fop.FillNA)
+
+    @pytest.mark.parametrize(
+        "columns, expected_length",
+        [
+            (["nan", "nan"], 2),
+            ([], 0),
+        ],
     )
+    def but_it_raises_valueerror_with_columns_length_different_than_1(
+        self, columns, expected_length
+    ):
+        with pytest.raises(ValueError) as err:
+            fillna = fop.FillNA(columns=columns, value=0)
 
-    filled_dataset = fillna_fop(dataset)
+        assert isinstance(err.value, ValueError)
+        assert f"Length of columns must be 1, found {expected_length}" == str(err.value)
 
-    fillna_.assert_called_once_with(
-        dataset,
-        columns=columns,
-        derived_columns=derived_columns,
-        value=value,
-        inplace=False,
+    @pytest.mark.parametrize(
+        "derived_columns, expected_length",
+        [
+            (["nan", "nan"], 2),
+            ([], 0),
+        ],
     )
-    assert isinstance(filled_dataset, Dataset)
+    def but_it_raises_valueerror_with_derived_columns_length_different_than_1(
+        self, derived_columns, expected_length
+    ):
+        with pytest.raises(ValueError) as err:
+            fillna = fop.FillNA(
+                columns=["nan"], derived_columns=derived_columns, value=0
+            )
+
+        assert isinstance(err.value, ValueError)
+        assert f"Length of derived_columns must be 1, found {expected_length}" == str(
+            err.value
+        )
+
+    def it_calls_fillna(self, request):
+        initializer_mock(request, Dataset)
+        fillna_ = method_mock(request, Dataset, "fillna")
+        fillna_.return_value = Dataset("fake/path")
+        dataset = Dataset("fake/path")
+        columns = ["nan_0"]
+        derived_columns = ["filled_0"]
+        value = 0
+        fillna_fop = fop.FillNA(
+            columns=columns, derived_columns=derived_columns, value=value
+        )
+
+        filled_dataset = fillna_fop(dataset)
+
+        fillna_.assert_called_once_with(
+            dataset,
+            columns=columns,
+            derived_columns=derived_columns,
+            value=value,
+            inplace=False,
+        )
+        assert isinstance(filled_dataset, Dataset)


### PR DESCRIPTION
It has to accept list parameters for `columns` and `derived_columns` to be compliant with `FeatureOperation`.
Additional checks are needed to ensure that the lists provided are composed of a single element

Reverts HK3-Lab-Team/pytrousse#71