### PR TITLE
Add OperationList

### DIFF
--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -6,7 +6,7 @@ import os
 import shelve
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pandas as pd
 import sklearn
@@ -20,7 +20,7 @@ from .exceptions import (
 from .feature_enum import OperationTypeEnum
 from .feature_operation import FeatureOperation
 from .settings import CATEG_COL_THRESHOLD
-from .util import lazy_property
+from .util import lazy_property, tolist
 
 logger = logging.getLogger(__name__)
 

--- a/src/trousse/dataset.py
+++ b/src/trousse/dataset.py
@@ -6,7 +6,7 @@ import os
 import shelve
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import pandas as pd
 import sklearn
@@ -20,7 +20,7 @@ from .exceptions import (
 from .feature_enum import OperationTypeEnum
 from .feature_operation import FeatureOperation
 from .settings import CATEG_COL_THRESHOLD
-from .util import lazy_property, tolist
+from .util import lazy_property
 
 logger = logging.getLogger(__name__)
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -32,6 +32,28 @@ class _OperationsList:
         self._operations_list = []
         self._operations_by_column = collections.defaultdict(list)
 
+    def derived_columns_from_col(self, column: str) -> List[str]:
+        """Return name of the columns created by FeatureOperations applied on ``column``
+
+        Parameters
+        ----------
+        column : str
+            The column on which the FeatureOperation has been applied on.
+
+        Returns
+        -------
+        List[str]
+            Name of the columns created by FeatureOperations applied on ``column``.
+        """
+        derived_columns = []
+        operations = self[column]
+
+        for operation in operations:
+            if column in operation.columns and operation.derived_columns is not None:
+                derived_columns.extend(operation.derived_columns)
+
+        return derived_columns
+
     def __iadd__(self, feat_op: FeatureOperation):
         self._operations_list.append(feat_op)
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -54,6 +54,57 @@ class _OperationsList:
 
         return derived_columns
 
+    def original_columns_from_derived_column(self, derived_column: str) -> List[str]:
+        """Return the name of the columns from which ``derived_column`` is generated from.
+
+        Parameters
+        ----------
+        derived_column : str
+            The column that has been generated
+
+        Returns
+        -------
+        List[str]
+            Name of the columns from which ``derived_column`` has been generated from.
+        """
+        operations = self._operations_from_derived_column(derived_column)
+
+        if len(operations) > 1:
+            raise RuntimeError(
+                "Multiple FeatureOperation found that generated column "
+                f"{derived_column}... the pipeline is compromised"
+            )
+        if len(operations) == 0:
+            raise RuntimeError(
+                "No FeatureOperation found that generated column "
+                f"{derived_column}... the pipeline is compromised"
+            )
+
+        return operations[0].columns
+
+    def _operations_from_derived_column(
+        self, derived_column: str
+    ) -> List[FeatureOperation]:
+        """Return the FeatureOperations that generated ``derived_column``
+
+        Parameters
+        ----------
+        derived_column : str
+            The column that has been generated
+
+        Returns
+        -------
+        List[FeatureOperation]
+            FeatureOperations that generated ``derived_column``
+        """
+        return list(
+            filter(
+                lambda op: op.derived_columns is not None
+                and derived_column in op.derived_columns,
+                self[derived_column],
+            )
+        )
+
     def __iadd__(self, feat_op: FeatureOperation):
         self._operations_list.append(feat_op)
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -110,7 +110,9 @@ class _OperationsList:
 
         columns = tolist(feat_op.columns)
         derived_columns = (
-            tolist(feat_op.derived_columns) if feat_op.derived_columns else None
+            tolist(feat_op.derived_columns)
+            if feat_op.derived_columns is not None
+            else []
         )
 
         for column in columns + derived_columns:

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -118,6 +118,10 @@ class _OperationsList:
 
         return self
 
+    def __iter__(self):
+        for operation in self._operations_list:
+            yield operation
+
     def __getitem__(
         self, label: Union[int, str]
     ) -> Union[FeatureOperation, List[FeatureOperation]]:
@@ -148,6 +152,9 @@ class _OperationsList:
             raise TypeError(
                 f"Cannot get FeatureOperation with a label of type {type(label).__name__}"
             )
+
+    def __len__(self):
+        return len(self._operations_list)
 
 
 class FillNA(FeatureOperation):

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -145,13 +145,13 @@ class FillNA(FeatureOperation):
         if len(columns) != 1:
             raise ValueError(f"Length of columns must be 1, found {len(columns)}")
         if derived_columns is not None:
+            if not is_sequence_and_not_str(derived_columns):
+                raise TypeError(
+                    f"derived_columns parameter must be a list, found {type(derived_columns).__name__}"
+                )
             if len(derived_columns) != 1:
                 raise ValueError(
                     f"Length of derived_columns must be 1, found {len(derived_columns)}"
-                )
-            if not is_sequence_and_not_str(columns):
-                raise TypeError(
-                    f"derived_columns parameter must be a list, found {type(derived_columns).__name__}"
                 )
 
         self.columns = columns

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -5,10 +5,10 @@ except ImportError:
 
 import collections
 from abc import abstractmethod
-from typing import Any, List
+from typing import Any, List, Union
 
 from .dataset import Dataset
-from .util import tolist
+from .util import is_sequence_and_not_str, tolist
 
 
 @runtime_checkable
@@ -104,6 +104,10 @@ class FillNA(FeatureOperation):
     ------
     ValueError
         If ``columns`` or ``derived_columns`` are not a single-element list.
+    TypeError
+            If ``columns`` is not a list
+    TypeError
+        If ``derived_columns`` is not None and it is not a list
     """
 
     def __init__(
@@ -112,12 +116,21 @@ class FillNA(FeatureOperation):
         value: Any,
         derived_columns: List[str] = None,
     ):
+        if not is_sequence_and_not_str(columns):
+            raise TypeError(
+                f"columns parameter must be a list, found {type(columns).__name__}"
+            )
         if len(columns) != 1:
             raise ValueError(f"Length of columns must be 1, found {len(columns)}")
-        if derived_columns is not None and len(derived_columns) != 1:
-            raise ValueError(
-                f"Length of derived_columns must be 1, found {len(derived_columns)}"
-            )
+        if derived_columns is not None:
+            if len(derived_columns) != 1:
+                raise ValueError(
+                    f"Length of derived_columns must be 1, found {len(derived_columns)}"
+                )
+            if not is_sequence_and_not_str(columns):
+                raise TypeError(
+                    f"derived_columns parameter must be a list, found {type(derived_columns).__name__}"
+                )
 
         self.columns = columns
         self.derived_columns = derived_columns

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -73,7 +73,7 @@ class _OperationsList:
             return self._operations_by_column[label]
         else:
             raise TypeError(
-                f"Cannot get FeatureOperation with a label of type {type(label)}"
+                f"Cannot get FeatureOperation with a label of type {type(label).__name__}"
             )
 
 

--- a/src/trousse/feature_operations.py
+++ b/src/trousse/feature_operations.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from typing import Any, List, Union
 
 from .dataset import Dataset
-from .util import is_sequence_and_not_str, tolist
+from .util import is_sequence_and_not_str
 
 
 @runtime_checkable
@@ -108,14 +108,11 @@ class _OperationsList:
     def __iadd__(self, feat_op: FeatureOperation):
         self._operations_list.append(feat_op)
 
-        columns = tolist(feat_op.columns)
         derived_columns = (
-            tolist(feat_op.derived_columns)
-            if feat_op.derived_columns is not None
-            else []
+            feat_op.derived_columns if feat_op.derived_columns is not None else []
         )
 
-        for column in columns + derived_columns:
+        for column in feat_op.columns + derived_columns:
             self._operations_by_column[column].append(feat_op)
 
         return self

--- a/src/trousse/util.py
+++ b/src/trousse/util.py
@@ -1,6 +1,26 @@
 import functools
-from typing import Any, Callable
+from typing import Any, Callable, Iterable, List
 
 
 def lazy_property(f: Callable[..., Any]):
     return property(functools.lru_cache()(f))
+
+
+def tolist(iterable: Iterable) -> List[Any]:
+    """Convert any iterable to a list. A string is converted to a single element list.
+
+    Parameters
+    ----------
+    iterable : Iterable[Any]
+        The object to convert
+
+    Returns
+    -------
+    List[Any]
+        List after conversion
+    """
+    if isinstance(iterable, str):
+        iterable = [iterable]
+    elif not isinstance(iterable, list):
+        iterable = list(iterable)
+    return iterable

--- a/src/trousse/util.py
+++ b/src/trousse/util.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, Iterable, List
+from typing import Any, Callable, Iterable, List, Sequence
 
 
 def lazy_property(f: Callable[..., Any]):
@@ -24,3 +24,19 @@ def tolist(iterable: Iterable) -> List[Any]:
     elif not isinstance(iterable, list):
         iterable = list(iterable)
     return iterable
+
+
+def is_sequence_and_not_str(obj: Any) -> bool:
+    """Return True if ``obj`` is a sequence object but not a string.
+
+    Parameters
+    ----------
+    obj : Any
+        Object to check
+
+    Returns
+    -------
+    bool
+        True if ``obj`` is a sequence object but not a string
+    """
+    return not isinstance(obj, str) and isinstance(obj, Sequence)

--- a/src/trousse/util.py
+++ b/src/trousse/util.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, Iterable, List, Sequence
+from typing import Any, Callable, Sequence
 
 
 def lazy_property(f: Callable[..., Any]):

--- a/src/trousse/util.py
+++ b/src/trousse/util.py
@@ -6,26 +6,6 @@ def lazy_property(f: Callable[..., Any]):
     return property(functools.lru_cache()(f))
 
 
-def tolist(iterable: Iterable) -> List[Any]:
-    """Convert any iterable to a list. A string is converted to a single element list.
-
-    Parameters
-    ----------
-    iterable : Iterable[Any]
-        The object to convert
-
-    Returns
-    -------
-    List[Any]
-        List after conversion
-    """
-    if isinstance(iterable, str):
-        iterable = [iterable]
-    elif not isinstance(iterable, list):
-        iterable = list(iterable)
-    return iterable
-
-
 def is_sequence_and_not_str(obj: Any) -> bool:
     """Return True if ``obj`` is a sequence object but not a string.
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -14,7 +14,7 @@ class DescribeDataset:
         "metadata_cols",
         [
             (("metadata_num_col")),
-            (("metadata_num_col, string_col")),
+            (("metadata_num_col", "string_col")),
             (()),
         ],
     )

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -136,8 +136,6 @@ class DescribeOperationsList:
         assert isinstance(operations_list, fop._OperationsList)
 
     def it_can_iadd_first_featop(self, request, fillna_col0_col1):
-        tolist_ = function_mock(request, "trousse.feature_operations.tolist")
-        tolist_.side_effect = ["col0"], ["col1"]
         op_list = fop._OperationsList()
 
         op_list += fillna_col0_col1
@@ -145,14 +143,8 @@ class DescribeOperationsList:
         assert op_list._operations_list == [fillna_col0_col1]
         for column in ["col0", "col1"]:
             assert op_list._operations_by_column[column] == [fillna_col0_col1]
-        assert tolist_.call_args_list == [
-            call(["col0"]),
-            call(["col1"]),
-        ]
 
     def it_can_iadd_next_featop(self, request, fillna_col0_col1, fillna_col4_none):
-        tolist_ = function_mock(request, "trousse.feature_operations.tolist")
-        tolist_.side_effect = [["col4"], None]
         op_list = fop._OperationsList()
         op_list._operations_list = [fillna_col0_col1]
         for column in ["col0", "col1"]:
@@ -166,9 +158,6 @@ class DescribeOperationsList:
             fillna_col0_col1,
         ]
         assert op_list._operations_by_column["col4"] == [fillna_col4_none]
-        assert tolist_.call_args_list == [
-            call(["col4"]),
-        ]
 
     def it_can_getitem_from_int(self, fillna_col0_col1, fillna_col1_col4):
         op_list = fop._OperationsList()

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -1,8 +1,10 @@
+from unittest.mock import call
+
 import pytest
 from trousse import feature_operations as fop
 from trousse.dataset import Dataset
 
-from ..unitutil import ANY, initializer_mock, method_mock
+from ..unitutil import ANY, function_mock, initializer_mock, method_mock
 
 
 class DescribeFillNa:
@@ -72,3 +74,95 @@ class DescribeFillNa:
             inplace=False,
         )
         assert isinstance(filled_dataset, Dataset)
+
+
+class DescribeOperationsList:
+    def it_can_construct_itself(self, request):
+        _init_ = initializer_mock(request, fop._OperationsList)
+
+        operations_list = fop._OperationsList()
+
+        _init_.assert_called_once_with(ANY)
+        assert isinstance(operations_list, fop._OperationsList)
+
+    def it_can_iadd_first_featop(self, request):
+        tolist_ = function_mock(request, "trousse.feature_operations.tolist")
+        tolist_.side_effect = [["col0", "col1"], ["col2", "col3"]]
+        op_list = fop._OperationsList()
+        feat_op = fop.FillNA(
+            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
+        )
+
+        op_list += feat_op
+
+        assert op_list._operations_list == [feat_op]
+        for column in ["col0", "col1", "col2", "col3"]:
+            assert op_list._operations_by_column[column] == [feat_op]
+        assert tolist_.call_args_list == [
+            call(["col0", "col1"]),
+            call(["col2", "col3"]),
+        ]
+
+    def it_can_iadd_next_featop(self, request):
+        tolist_ = function_mock(request, "trousse.feature_operations.tolist")
+        tolist_.side_effect = [["col1"], ["col4"]]
+        op_list = fop._OperationsList()
+        feat_op0 = fop.FillNA(
+            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
+        )
+        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        op_list._operations_list = [feat_op0]
+        for column in ["col0", "col1", "col2", "col3"]:
+            op_list._operations_by_column[column] = [feat_op0]
+
+        op_list += feat_op1
+
+        assert op_list._operations_list == [feat_op0, feat_op1]
+        for column in ["col0", "col2", "col3"]:
+            assert op_list._operations_by_column[column] == [feat_op0]
+        assert op_list._operations_by_column["col1"] == [feat_op0, feat_op1]
+        assert op_list._operations_by_column["col4"] == [feat_op1]
+        assert tolist_.call_args_list == [
+            call("col1"),
+            call("col4"),
+        ]
+
+    def it_can_getitem_from_int(self):
+        op_list = fop._OperationsList()
+        feat_op0 = fop.FillNA(
+            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
+        )
+        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        op_list._operations_list = [feat_op0, feat_op1]
+        for column in ["col0", "col2", "col3"]:
+            op_list._operations_by_column[column] = [feat_op0]
+        op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
+        op_list._operations_by_column["col4"] = [feat_op1]
+
+        feat_op0_ = op_list[0]
+        feat_op1_ = op_list[1]
+
+        assert isinstance(feat_op0_, fop.FillNA)
+        assert isinstance(feat_op1_, fop.FillNA)
+        assert feat_op0_ == feat_op0
+        assert feat_op1_ == feat_op1
+
+    def it_can_getitem_from_str(self):
+        op_list = fop._OperationsList()
+        feat_op0 = fop.FillNA(
+            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
+        )
+        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        op_list._operations_list = [feat_op0, feat_op1]
+        for column in ["col0", "col2", "col3"]:
+            op_list._operations_by_column[column] = [feat_op0]
+        op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
+        op_list._operations_by_column["col4"] = [feat_op1]
+
+        feat_op_col0 = op_list["col0"]
+        feat_op_col1 = op_list["col1"]
+
+        assert isinstance(feat_op_col0, list)
+        assert isinstance(feat_op_col1, list)
+        assert feat_op_col0 == [feat_op0]
+        assert feat_op_col1 == [feat_op0, feat_op1]

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -331,12 +331,12 @@ class DescribeOperationsList:
             fillna_col1_col4,
             fillna_col1_col2,
         ]
-        l = []
+        operations = []
         for operation in op_list:
-            l.append(operation)
+            operations.append(operation)
 
         assert isinstance(op_list, Iterable)
-        assert l == [
+        assert operations == [
             fillna_col0_col1,
             fillna_col1_col4,
             fillna_col1_col2,

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from unittest.mock import call
 
 import pytest
 from trousse import feature_operations as fop

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -87,55 +87,48 @@ class DescribeOperationsList:
 
     def it_can_iadd_first_featop(self, request):
         tolist_ = function_mock(request, "trousse.feature_operations.tolist")
-        tolist_.side_effect = [["col0", "col1"], ["col2", "col3"]]
+        tolist_.side_effect = ["col0"], ["col1"]
         op_list = fop._OperationsList()
-        feat_op = fop.FillNA(
-            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
-        )
+        feat_op = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
 
         op_list += feat_op
 
         assert op_list._operations_list == [feat_op]
-        for column in ["col0", "col1", "col2", "col3"]:
+        for column in ["col0", "col1"]:
             assert op_list._operations_by_column[column] == [feat_op]
         assert tolist_.call_args_list == [
-            call(["col0", "col1"]),
-            call(["col2", "col3"]),
+            call(["col0"]),
+            call(["col1"]),
         ]
 
     def it_can_iadd_next_featop(self, request):
         tolist_ = function_mock(request, "trousse.feature_operations.tolist")
         tolist_.side_effect = [["col1"], ["col4"]]
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(
-            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
-        )
-        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
+        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
         op_list._operations_list = [feat_op0]
-        for column in ["col0", "col1", "col2", "col3"]:
+        for column in ["col0", "col1"]:
             op_list._operations_by_column[column] = [feat_op0]
 
         op_list += feat_op1
 
         assert op_list._operations_list == [feat_op0, feat_op1]
-        for column in ["col0", "col2", "col3"]:
-            assert op_list._operations_by_column[column] == [feat_op0]
+
+        assert op_list._operations_by_column["col0"] == [feat_op0]
         assert op_list._operations_by_column["col1"] == [feat_op0, feat_op1]
         assert op_list._operations_by_column["col4"] == [feat_op1]
         assert tolist_.call_args_list == [
-            call("col1"),
-            call("col4"),
+            call(["col1"]),
+            call(["col4"]),
         ]
 
     def it_can_getitem_from_int(self):
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(
-            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
-        )
-        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
+        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
         op_list._operations_list = [feat_op0, feat_op1]
-        for column in ["col0", "col2", "col3"]:
-            op_list._operations_by_column[column] = [feat_op0]
+        op_list._operations_by_column["col0"] = [feat_op0]
         op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
         op_list._operations_by_column["col4"] = [feat_op1]
 
@@ -149,13 +142,10 @@ class DescribeOperationsList:
 
     def it_can_getitem_from_str(self):
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(
-            columns=["col0", "col1"], derived_columns=["col2", "col3"], value=0
-        )
-        feat_op1 = fop.FillNA(columns="col1", derived_columns="col4", value=1)
+        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
+        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
         op_list._operations_list = [feat_op0, feat_op1]
-        for column in ["col0", "col2", "col3"]:
-            op_list._operations_by_column[column] = [feat_op0]
+        op_list._operations_by_column["col0"] = [feat_op0]
         op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
         op_list._operations_by_column["col4"] = [feat_op1]
 

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -73,6 +73,24 @@ class DescribeFillNa:
             err.value
         )
 
+    @pytest.mark.parametrize(
+        "derived_columns, expected_type",
+        [("nan", "str"), (dict(), "dict"), (set(), "set")],
+    )
+    def but_it_raises_typeerror_with_derived_columns_not_list(
+        self, derived_columns, expected_type, is_sequence_and_not_str_
+    ):
+        is_sequence_and_not_str_.side_effect = [True, False]
+
+        with pytest.raises(TypeError) as err:
+            fop.FillNA(columns=["nan"], derived_columns=derived_columns, value=0)
+
+        assert isinstance(err.value, TypeError)
+        assert (
+            f"derived_columns parameter must be a list, found {expected_type}"
+            == str(err.value)
+        )
+
     def it_calls_fillna(self, request):
         initializer_mock(request, Dataset)
         fillna_ = method_mock(request, Dataset, "fillna")

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from unittest.mock import call
 
 import pytest
@@ -311,6 +312,35 @@ class DescribeOperationsList:
             "No FeatureOperation found that generated column "
             "col1... the pipeline is compromised"
         ) == str(err.value)
+
+    def it_knows_its_len(self, fillna_col0_col1, fillna_col1_col4):
+        op_list = fop._OperationsList()
+        op_list._operations_list = [fillna_col0_col1, fillna_col1_col4]
+
+        len_ = len(op_list)
+
+        assert type(len_) == int
+        assert len_ == 2
+
+    def it_can_be_iterated_over(
+        self, fillna_col0_col1, fillna_col1_col4, fillna_col1_col2
+    ):
+        op_list = fop._OperationsList()
+        op_list._operations_list = [
+            fillna_col0_col1,
+            fillna_col1_col4,
+            fillna_col1_col2,
+        ]
+        l = []
+        for operation in op_list:
+            l.append(operation)
+
+        assert isinstance(op_list, Iterable)
+        assert l == [
+            fillna_col0_col1,
+            fillna_col1_col4,
+            fillna_col1_col2,
+        ]
 
     # ====================
     #      FIXTURES

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -166,3 +166,12 @@ class DescribeOperationsList:
         assert isinstance(feat_op_col1, list)
         assert feat_op_col0 == [feat_op0]
         assert feat_op_col1 == [feat_op0, feat_op1]
+
+    def but_it_raisestypeerror_with_wrong_type(self):
+        op_list = fop._OperationsList()
+
+        with pytest.raises(TypeError) as err:
+            op_list[{"wrong"}]
+
+        assert isinstance(err.value, TypeError)
+        assert "Cannot get FeatureOperation with a label of type set" == str(err.value)

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -26,8 +26,10 @@ class DescribeFillNa:
         ],
     )
     def but_it_raises_valueerror_with_columns_length_different_than_1(
-        self, columns, expected_length
+        self, columns, expected_length, is_sequence_and_not_str_
     ):
+        is_sequence_and_not_str_.return_value = True
+
         with pytest.raises(ValueError) as err:
             fop.FillNA(columns=columns, value=0)
 
@@ -42,13 +44,32 @@ class DescribeFillNa:
         ],
     )
     def but_it_raises_valueerror_with_derived_columns_length_different_than_1(
-        self, derived_columns, expected_length
+        self, derived_columns, expected_length, is_sequence_and_not_str_
     ):
+        is_sequence_and_not_str_.return_value = True
+
         with pytest.raises(ValueError) as err:
             fop.FillNA(columns=["nan"], derived_columns=derived_columns, value=0)
 
         assert isinstance(err.value, ValueError)
         assert f"Length of derived_columns must be 1, found {expected_length}" == str(
+            err.value
+        )
+
+    @pytest.mark.parametrize(
+        "columns, expected_type",
+        [("nan", "str"), (dict(), "dict"), (set(), "set")],
+    )
+    def but_it_raises_typeerror_with_columns_not_list(
+        self, columns, expected_type, is_sequence_and_not_str_
+    ):
+        is_sequence_and_not_str_.return_value = False
+
+        with pytest.raises(TypeError) as err:
+            fop.FillNA(columns=columns, value=0)
+
+        assert isinstance(err.value, TypeError)
+        assert f"columns parameter must be a list, found {expected_type}" == str(
             err.value
         )
 
@@ -74,6 +95,16 @@ class DescribeFillNa:
             inplace=False,
         )
         assert isinstance(filled_dataset, Dataset)
+
+    # ====================
+    #      FIXTURES
+    # ====================
+
+    @pytest.fixture
+    def is_sequence_and_not_str_(self, request):
+        return function_mock(
+            request, "trousse.feature_operations.is_sequence_and_not_str"
+        )
 
 
 class DescribeOperationsList:

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -150,26 +150,23 @@ class DescribeOperationsList:
             call(["col1"]),
         ]
 
-    def it_can_iadd_next_featop(self, request, fillna_col0_col1, fillna_col1_col4):
+    def it_can_iadd_next_featop(self, request, fillna_col0_col1, fillna_col4_none):
         tolist_ = function_mock(request, "trousse.feature_operations.tolist")
-        tolist_.side_effect = [["col1"], ["col4"]]
+        tolist_.side_effect = [["col4"], None]
         op_list = fop._OperationsList()
         op_list._operations_list = [fillna_col0_col1]
         for column in ["col0", "col1"]:
             op_list._operations_by_column[column] = [fillna_col0_col1]
 
-        op_list += fillna_col1_col4
+        op_list += fillna_col4_none
 
-        assert op_list._operations_list == [fillna_col0_col1, fillna_col1_col4]
-
+        assert op_list._operations_list == [fillna_col0_col1, fillna_col4_none]
         assert op_list._operations_by_column["col0"] == [fillna_col0_col1]
         assert op_list._operations_by_column["col1"] == [
             fillna_col0_col1,
-            fillna_col1_col4,
         ]
-        assert op_list._operations_by_column["col4"] == [fillna_col1_col4]
+        assert op_list._operations_by_column["col4"] == [fillna_col4_none]
         assert tolist_.call_args_list == [
-            call(["col1"]),
             call(["col4"]),
         ]
 

--- a/tests/unit/test_feature_operations.py
+++ b/tests/unit/test_feature_operations.py
@@ -116,77 +116,73 @@ class DescribeOperationsList:
         _init_.assert_called_once_with(ANY)
         assert isinstance(operations_list, fop._OperationsList)
 
-    def it_can_iadd_first_featop(self, request):
+    def it_can_iadd_first_featop(self, request, fillna_col0_col1):
         tolist_ = function_mock(request, "trousse.feature_operations.tolist")
         tolist_.side_effect = ["col0"], ["col1"]
         op_list = fop._OperationsList()
-        feat_op = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
 
-        op_list += feat_op
+        op_list += fillna_col0_col1
 
-        assert op_list._operations_list == [feat_op]
+        assert op_list._operations_list == [fillna_col0_col1]
         for column in ["col0", "col1"]:
-            assert op_list._operations_by_column[column] == [feat_op]
+            assert op_list._operations_by_column[column] == [fillna_col0_col1]
         assert tolist_.call_args_list == [
             call(["col0"]),
             call(["col1"]),
         ]
 
-    def it_can_iadd_next_featop(self, request):
+    def it_can_iadd_next_featop(self, request, fillna_col0_col1, fillna_col1_col4):
         tolist_ = function_mock(request, "trousse.feature_operations.tolist")
         tolist_.side_effect = [["col1"], ["col4"]]
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
-        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
-        op_list._operations_list = [feat_op0]
+        op_list._operations_list = [fillna_col0_col1]
         for column in ["col0", "col1"]:
-            op_list._operations_by_column[column] = [feat_op0]
+            op_list._operations_by_column[column] = [fillna_col0_col1]
 
-        op_list += feat_op1
+        op_list += fillna_col1_col4
 
-        assert op_list._operations_list == [feat_op0, feat_op1]
+        assert op_list._operations_list == [fillna_col0_col1, fillna_col1_col4]
 
-        assert op_list._operations_by_column["col0"] == [feat_op0]
-        assert op_list._operations_by_column["col1"] == [feat_op0, feat_op1]
-        assert op_list._operations_by_column["col4"] == [feat_op1]
+        assert op_list._operations_by_column["col0"] == [fillna_col0_col1]
+        assert op_list._operations_by_column["col1"] == [
+            fillna_col0_col1,
+            fillna_col1_col4,
+        ]
+        assert op_list._operations_by_column["col4"] == [fillna_col1_col4]
         assert tolist_.call_args_list == [
             call(["col1"]),
             call(["col4"]),
         ]
 
-    def it_can_getitem_from_int(self):
+    def it_can_getitem_from_int(self, fillna_col0_col1, fillna_col1_col4):
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
-        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
-        op_list._operations_list = [feat_op0, feat_op1]
-        op_list._operations_by_column["col0"] = [feat_op0]
-        op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
-        op_list._operations_by_column["col4"] = [feat_op1]
+        op_list._operations_list = [fillna_col0_col1, fillna_col1_col4]
+        op_list._operations_by_column["col0"] = [fillna_col0_col1]
+        op_list._operations_by_column["col1"] = [fillna_col0_col1, fillna_col1_col4]
+        op_list._operations_by_column["col4"] = [fillna_col1_col4]
 
         feat_op0_ = op_list[0]
         feat_op1_ = op_list[1]
 
         assert isinstance(feat_op0_, fop.FillNA)
         assert isinstance(feat_op1_, fop.FillNA)
-        assert feat_op0_ == feat_op0
-        assert feat_op1_ == feat_op1
+        assert feat_op0_ == fillna_col0_col1
+        assert feat_op1_ == fillna_col1_col4
 
-    def it_can_getitem_from_str(self):
+    def it_can_getitem_from_str(self, fillna_col0_col1, fillna_col1_col4):
         op_list = fop._OperationsList()
-        feat_op0 = fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
-        feat_op1 = fop.FillNA(columns=["col1"], derived_columns=["col4"], value=1)
-        op_list._operations_list = [feat_op0, feat_op1]
-        op_list._operations_by_column["col0"] = [feat_op0]
-        op_list._operations_by_column["col1"] = [feat_op0, feat_op1]
-        op_list._operations_by_column["col4"] = [feat_op1]
+        op_list._operations_list = [fillna_col0_col1, fillna_col1_col4]
+        op_list._operations_by_column["col0"] = [fillna_col0_col1]
+        op_list._operations_by_column["col1"] = [fillna_col0_col1, fillna_col1_col4]
+        op_list._operations_by_column["col4"] = [fillna_col1_col4]
 
         feat_op_col0 = op_list["col0"]
         feat_op_col1 = op_list["col1"]
 
         assert isinstance(feat_op_col0, list)
         assert isinstance(feat_op_col1, list)
-        assert feat_op_col0 == [feat_op0]
-        assert feat_op_col1 == [feat_op0, feat_op1]
+        assert feat_op_col0 == [fillna_col0_col1]
+        assert feat_op_col1 == [fillna_col0_col1, fillna_col1_col4]
 
     def but_it_raisestypeerror_with_wrong_type(self):
         op_list = fop._OperationsList()
@@ -196,3 +192,62 @@ class DescribeOperationsList:
 
         assert isinstance(err.value, TypeError)
         assert "Cannot get FeatureOperation with a label of type set" == str(err.value)
+
+    @pytest.mark.parametrize(
+        "columns, getitem_return_value, expected_derived_columns",
+        [
+            (
+                "col0",
+                [fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)],
+                ["col1"],
+            ),
+            (
+                "col1",
+                [
+                    fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0),
+                    fop.FillNA(columns=["col1"], derived_columns=["col4"], value=0),
+                    fop.FillNA(columns=["col1"], derived_columns=["col2"], value=0),
+                ],
+                ["col4", "col2"],
+            ),
+            (
+                "col4",
+                [
+                    fop.FillNA(columns=["col1"], derived_columns=["col1"], value=0),
+                    fop.FillNA(columns=["col4"], derived_columns=None, value=0),
+                ],
+                [],
+            ),
+        ],
+    )
+    def it_can_get_derived_columns_from_col(
+        self, request, columns, getitem_return_value, expected_derived_columns
+    ):
+        op_list = fop._OperationsList()
+        getitem_ = method_mock(request, fop._OperationsList, "__getitem__")
+        getitem_.return_value = getitem_return_value
+
+        derived_columns = op_list.derived_columns_from_col(columns)
+
+        assert type(derived_columns) == list
+        assert derived_columns == expected_derived_columns
+
+    # ====================
+    #      FIXTURES
+    # ====================
+
+    @pytest.fixture
+    def fillna_col0_col1(self, request):
+        return fop.FillNA(columns=["col0"], derived_columns=["col1"], value=0)
+
+    @pytest.fixture
+    def fillna_col1_col4(self, request):
+        return fop.FillNA(columns=["col1"], derived_columns=["col4"], value=0)
+
+    @pytest.fixture
+    def fillna_col4_none(self, request):
+        return fop.FillNA(columns=["col4"], derived_columns=None, value=0)
+
+    @pytest.fixture
+    def fillna_col1_col2(self, request):
+        return fop.FillNA(columns=["col1"], derived_columns=["col2"], value=0)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 from trousse import util
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from trousse import util
 
 
@@ -26,3 +25,14 @@ def but_it_raises_typeerror_with_none():
 
     assert isinstance(err.value, TypeError)
     assert str(err.value) == "'NoneType' object is not iterable"
+
+
+@pytest.mark.parametrize(
+    "obj, expected_result",
+    (("nan", False), (dict(), False), (set(), False), ([1, 2, 3], True), ([], True)),
+)
+def test_is_sequence_and_not_str(obj, expected_result):
+    result = util.is_sequence_and_not_str(obj)
+
+    assert isinstance(result, bool)
+    assert result == expected_result

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from trousse import util
+
+
+@pytest.mark.parametrize(
+    "iterable, expected_list",
+    [
+        ("str", ["str"]),
+        (["hello", "hello2"], ["hello", "hello2"]),
+        (("hello", "hello2"), ["hello", "hello2"]),
+        (np.array([0, 1, 2]), [0, 1, 2]),
+    ],
+)
+def test_tolist(iterable, expected_list):
+    list_ = util.tolist(iterable)
+
+    assert type(list_) == list
+    assert list_ == expected_list
+
+
+def but_it_raises_typeerror_with_none():
+    with pytest.raises(TypeError) as err:
+        util.tolist(None)
+
+    assert isinstance(err.value, TypeError)
+    assert str(err.value) == "'NoneType' object is not iterable"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -4,30 +4,6 @@ from trousse import util
 
 
 @pytest.mark.parametrize(
-    "iterable, expected_list",
-    [
-        ("str", ["str"]),
-        (["hello", "hello2"], ["hello", "hello2"]),
-        (("hello", "hello2"), ["hello", "hello2"]),
-        (np.array([0, 1, 2]), [0, 1, 2]),
-    ],
-)
-def test_tolist(iterable, expected_list):
-    list_ = util.tolist(iterable)
-
-    assert type(list_) == list
-    assert list_ == expected_list
-
-
-def but_it_raises_typeerror_with_none():
-    with pytest.raises(TypeError) as err:
-        util.tolist(None)
-
-    assert isinstance(err.value, TypeError)
-    assert str(err.value) == "'NoneType' object is not iterable"
-
-
-@pytest.mark.parametrize(
     "obj, expected_result",
     (("nan", False), (dict(), False), (set(), False), ([1, 2, 3], True), ([], True)),
 )


### PR DESCRIPTION
`_OperationsList` is a Sequence containing `FeatureOperations`. The `FeatureOperation` can be accessed via square brackets using an index (to get the i-th operation) or using a string representing the column name (to get all the operations related to that column).
It can be iterated over and is possible to get the derived columns from a column or to get the original columns that generated a column.

An instance of `_OperationsList` will be contained in a `Dataset` to keep track of the preprocessing steps on that `Dataset` [implementation in a successive PR]

fixes #49 