### PR TITLE
Add set to nan in row fix

### DIFF
--- a/src/trousse/row_fix.py
+++ b/src/trousse/row_fix.py
@@ -354,6 +354,7 @@ class RowFix:
             Instance containing the new data where the non number-convertible values
             in ``columns`` have been set to the value ``nan_value``
         """
+        df_num_only = copy_df_info_with_new_df(df_info, df_info.df)
         non_num_convertible_values = 0
         if verbose:
             logger.info("The count of values non convertible to numbers per column is:")
@@ -367,15 +368,17 @@ class RowFix:
             if verbose:
                 logger.info(
                     f"{col} -> "
-                    f"{df_info.df[col][non_numeric_in_column.isna()].value_counts()}"
+                    f"{df_info.df[col][non_numeric_in_column.isna()].value_counts().values}"
                 )
             if not dry_run:
-                df_info.df.loc[non_numeric_in_column, col] = nan_value
+                df_num_only.df.loc[non_numeric_in_column, col] = nan_value
 
         logger.info(
             "The total count of values non convertible to numbers"
             f" is: {non_num_convertible_values}"
         )
+
+        return df_num_only
 
     def count_errors(self):
         """ This is to count errors before and after fixes"""

--- a/src/trousse/row_fix.py
+++ b/src/trousse/row_fix.py
@@ -330,9 +330,9 @@ class RowFix:
             )
 
     @staticmethod
-    def forced_conversion_to_numeric(
+    def force_conversion_to_numeric(
         df_info: DataFrameWithInfo,
-        columns: Iterable,
+        columns: Iterable[str],
         dry_run: bool = False,
         verbose: bool = True,
     ) -> DataFrameWithInfo:
@@ -345,26 +345,27 @@ class RowFix:
         Parameters
         ----------
         df_info : DataFrameWithInfo
-            Instance with the data that will be analyzed and set to NaN
-        columns : Iterable
+            Instance with the data that will be converted to numeric.
+        columns : Iterable[str]
             List of columns of ``df_info`` that will be analyzed and modified.
-            Usually it can be set to "mixed-type" columns.
+            Usually it can be set to mixed-type columns.
         dry_run : bool, optional
             If True, a dry run will be performed. Usually this is to check which
             and how many values are not numeric. If False, the non numeric
-            values will be converted to Nan. Default set to False.
+            values will be converted to NaN. Default set to False.
         verbose : bool, optional
-            If True,the function will log the non numeric values per column that will
+            If True, the function will log the non numeric values per column that will
             be set to NaN. If False, it will only log the total count of values
             converted to NaN. Default set to True.
 
         Returns
         -------
         DataFrameWithInfo
-            Instance containing the new data where the non number-convertible values
-            in ``columns`` have been set to the value ``nan_value``
+            Instance containing the new data where the values are converted to
+            numbers, if possible. The non number-convertible values in ``columns``
+            are set to NaN.
         """
-        df_num_only = copy_df_info_with_new_df(df_info, df_info.df)
+        dfinfo_num_only = copy_df_info_with_new_df(df_info, df_info.df)
         non_num_convertible_count = 0
         if verbose:
             logger.info("The values non convertible to numbers are:")
@@ -385,14 +386,14 @@ class RowFix:
                 )
             # Set to NaN all the non convertible values
             if not dry_run:
-                df_num_only.df.loc[:, col] = forced_converted_to_num
+                dfinfo_num_only.df.loc[:, col] = forced_converted_to_num
 
         logger.info(
             "The total count of values non convertible to numbers"
             f" is: {non_num_convertible_count}"
         )
 
-        return df_num_only
+        return dfinfo_num_only
 
     def count_errors(self):
         """ This is to count errors before and after fixes"""

--- a/tests/integration/test_row_fix.py
+++ b/tests/integration/test_row_fix.py
@@ -6,7 +6,7 @@ from src.trousse.dataframe_with_info import DataFrameWithInfo
 from trousse.row_fix import RowFix
 
 
-class Describe_RowFix:
+class DescribeRowFix:
     @pytest.mark.parametrize(
         "column, input_df, expected_df, dry_run",
         [
@@ -32,8 +32,8 @@ class Describe_RowFix:
             ),
         ],
     )
-    def test_forced_conversion_to_numeric(self, column, input_df, expected_df, dry_run):
-        dfinfo_converted = RowFix({}, {}).forced_conversion_to_numeric(
+    def test_force_conversion_to_numeric(self, column, input_df, expected_df, dry_run):
+        dfinfo_converted = RowFix({}, {}).force_conversion_to_numeric(
             DataFrameWithInfo(df_object=input_df),
             columns=[
                 column,

--- a/tests/integration/test_row_fix.py
+++ b/tests/integration/test_row_fix.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+from src.trousse.dataframe_with_info import DataFrameWithInfo
+from trousse.row_fix import RowFix
+
+
+class Describe_RowFix:
+    @pytest.mark.parametrize(
+        "column, input_df, expected_df, dry_run",
+        [
+            (
+                "col_a",
+                pd.DataFrame(
+                    {"col_a": [0, 1, 2, "e", "3", 5], "col_b": [0, 1, 2, "e", "3", 5]}
+                ),
+                pd.DataFrame(
+                    {"col_a": [0, 1, 2, "e", "3", 5], "col_b": [0, 1, 2, "e", "3", 5]}
+                ),
+                True,
+            ),
+            (
+                "col_a",
+                pd.DataFrame(
+                    {"col_a": [0, 1, 2, "e", "3", 5], "col_b": [0, 1, 2, "e", "3", 5]}
+                ),
+                pd.DataFrame(
+                    {"col_a": [0, 1, 2, np.nan, 3, 5], "col_b": [0, 1, 2, "e", "3", 5]}
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_forced_conversion_to_numeric(self, column, input_df, expected_df, dry_run):
+        dfinfo_converted = RowFix({}, {}).forced_conversion_to_numeric(
+            DataFrameWithInfo(df_object=input_df),
+            columns=[
+                column,
+            ],
+            dry_run=dry_run,
+        )
+
+        assert isinstance(dfinfo_converted, DataFrameWithInfo)
+        assert_frame_equal(dfinfo_converted.df, expected_df)


### PR DESCRIPTION
Added the method `forced_conversion_to_numeric` in RowFix class for converting some columns (usually mixed-type ones) to numeric (the non  convertible values are set to NaN).
This method also logs the converted value count and identities to allow the user to check the performance of this operation (in a `dry_run` too).