### PR TITLE
Fix issue for rie modelcomputation

### DIFF
--- a/src/trousse/dataframe_with_info.py
+++ b/src/trousse/dataframe_with_info.py
@@ -441,7 +441,6 @@ class DataFrameWithInfo:
             if unique_val_nb < 7 or (
                 unique_val_nb < self.df[col].count() // CATEG_COL_THRESHOLD
             ):
-                self.df[col] = self.df[col].astype("category")
                 categorical_cols.add(col)
 
         return categorical_cols


### PR DESCRIPTION
Removed column conversion to category 
During analysis pytrousse should not perform conversion to category (this would make the column a pd.Categorical instance, instead of pd.Series, and these are not a numpy arrays).

Replaced hardcoded values with arguments for `breed_specific_bin_splitting`